### PR TITLE
added search path for Hydrogen on OS/X

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ DrMr scans the following directories for hydrogen drum kits:
 - /usr/share/drmr/drumkits/
 - ~/.hydrogen/data/drumkits/
 - ~/.drmr/drumkits/
+- ~/Library/Application Support/Hydrogen/drumkits
 
 If you want to add others, add them to the default_drumkit_locations array at the top of drmr_hydrogen.c
 

--- a/drmr_hydrogen.c
+++ b/drmr_hydrogen.c
@@ -45,6 +45,7 @@ static char* default_drumkit_locations[] = {
   "/usr/share/drmr/drumkits/",
   "~/.hydrogen/data/drumkits/",
   "~/.drmr/drumkits/",
+  "~/Library/Application\ Support/Hydrogen/drumkits",
   NULL
 };
 


### PR DESCRIPTION
Drumkits that are downloaded via Hydrogen are stored in `~/Library/Application Support/Hydrogen/drumkits` by default
